### PR TITLE
Iteration 2 | Create `#renew_license`

### DIFF
--- a/lib/facility.rb
+++ b/lib/facility.rb
@@ -50,6 +50,10 @@ class Facility
     #returns nil:  registrant.license_data[:license] = true if registrant.license_data[:written] == true
     @services.include?('Road Test') && registrant.license_data[:written] == true ? registrant.license_data[:license] = true : false
   end
+
+  def renew_license(registrant)
+    @services.include?('Renew License') && registrant.license_data[:license] == true ? registrant.license_data[:renewed] = true : false
+  end
 end
 
 

--- a/lib/facility.rb
+++ b/lib/facility.rb
@@ -41,13 +41,12 @@ class Facility
     :regular
   end
 
+  # Future Refactor: Create a ServiceFactory since these are Duck Types:
   def administer_written_test(registrant)
-    #returns nil:  registrant.license_data[:written] = true if @services.include?('Written Test') && registrant.age? >= 16 
     @services.include?('Written Test') && registrant.age >= 16 && registrant.permit? == true ? registrant.license_data[:written] = true : false
   end
 
   def administer_road_test(registrant)
-    #returns nil:  registrant.license_data[:license] = true if registrant.license_data[:written] == true
     @services.include?('Road Test') && registrant.license_data[:written] == true ? registrant.license_data[:license] = true : false
   end
 

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -35,42 +35,73 @@ RSpec.describe Facility do
   describe '#add service' do
     it 'can add available services' do
       expect(facility_1.services).to eq([])
+      
       facility_1.add_service('New Drivers License')
       facility_1.add_service('Renew Drivers License')
       facility_1.add_service('Vehicle Registration')
+
       expect(facility_1.services).to eq(['New Drivers License', 'Renew Drivers License', 'Vehicle Registration'])
     end
   end
 
   describe 'services' do
+    let(:original_license_data) do 
+      {
+      written: false, 
+      license: false, 
+      renewed: false
+      }
+    end
+
+    let(:updated_license_data) do 
+      {
+      written: true, 
+      license: false, 
+      renewed: false
+      }
+    end
+
+    let(:received_license_data) do 
+      {
+      written: true, 
+      license: true, 
+      renewed: false
+      }
+    end
+
+    let(:renewed_license_data) do 
+      {
+      written: true, 
+      license: true, 
+      renewed: true
+      }
+    end
+
     describe '#register_vehicle' do
-      it 'can collected fees based on vehicle type' do
+      before(:each) do
         facility_1.add_service('Vehicle Registration')
+      end
+
+      it 'can collected fees based on vehicle type' do
         expect(facility_1.collected_fees).to eq(0)
         facility_1.register_vehicle(cruz)
         expect(facility_1.collected_fees).to eq(100)
       end
 
       it 'can set a vehicles plate type' do
-        facility_1.add_service('Vehicle Registration')
         expect(cruz.plate_type).to eq(nil)
-
         facility_1.register_vehicle(cruz)
         expect(cruz.plate_type).to eq(:regular)
       end
 
       it 'can add vehicle to facilitys registered_vehicles' do
-        facility_1.add_service('Vehicle Registration')
         expect(facility_1.registered_vehicles).to eq([])
-
         facility_1.register_vehicle(cruz)
         expect(facility_1.registered_vehicles).to eq([cruz])
       end
 
       it 'can add set a vehicles registration date' do
-        facility_1.add_service('Vehicle Registration')
         expect(cruz.registration_date).to eq(nil)
-
         facility_1.register_vehicle(cruz)
         expect(cruz.registration_date).to eq(Date.today)
       end
@@ -90,54 +121,17 @@ RSpec.describe Facility do
           facility_1.add_service('Written Test')
         end
 
-        let(:original_license_data) do 
-          {
-          written: false, 
-          license: false, 
-          renewed: false
-          }
-        end
-
-        let(:updated_license_data) do 
-          {
-          written: true, 
-          license: false, 
-          renewed: false
-          }
-        end
-
         it 'can administer a written test to a registrant (16+ age & has permit)' do
           expect(violet.license_data).to eq(original_license_data)
           expect(violet.permit?).to eq(true)
           expect(violet.age).to eq(16)
 
           facility_1.administer_written_test(violet)
-
           expect(violet.license_data).to eq(updated_license_data)
-        end
-
-        it 'can administer a written test to a registrant (16+ age) after earning a permit' do
-          expect(veruca.license_data).to eq(original_license_data)
-          expect(veruca.permit?).to eq(false)
-          expect(veruca.age).to eq(16)
-          expect(facility_1.administer_written_test(veruca)).to eq(false)
-
-          veruca.earn_permit
-          expect(veruca.permit?).to eq(true)
-          facility_1.administer_written_test(veruca)
-          expect(veruca.license_data).to eq(updated_license_data)
         end
       end
 
       describe 'sad path tests' do
-        let(:original_license_data) do 
-          {
-          written: false, 
-          license: false, 
-          renewed: false 
-          }
-        end
-
         it 'cannot administer a written test to a registrant if the facility does not offer that Service' do
           expect(violet.license_data).to eq(original_license_data)
           expect(violet.permit?).to eq(true)
@@ -178,38 +172,13 @@ RSpec.describe Facility do
           facility_1.add_service('Road Test')
         end
 
-        let(:original_license_data) do 
-          {
-          written: false, 
-          license: false, 
-          renewed: false
-          }
-        end
-
-        let(:updated_license_data) do 
-          {
-          written: true, 
-          license: false, 
-          renewed: false
-          }
-        end
-
-        let(:received_license_data) do 
-          {
-          written: true, 
-          license: true, 
-          renewed: false
-          }
-        end
-
         it 'can administer a road test if facility offers Service & give license to registrant who passes the written test' do
-          expect(veruca.license_data).to eq(original_license_data)
-          veruca.earn_permit
-          facility_1.administer_written_test(veruca)
-          expect(veruca.license_data).to eq(updated_license_data)
+          expect(violet.license_data).to eq(original_license_data)
+          facility_1.administer_written_test(violet)
+          expect(violet.license_data).to eq(updated_license_data)
 
-          expect(facility_1.administer_road_test(veruca)).to eq(true)
-          expect(veruca.license_data).to eq(received_license_data)
+          expect(facility_1.administer_road_test(violet)).to eq(true)
+          expect(violet.license_data).to eq(received_license_data)
         end
       end
 
@@ -218,30 +187,13 @@ RSpec.describe Facility do
           facility_1.add_service('Written Test')
         end
 
-        let(:original_license_data) do 
-          {
-          written: false, 
-          license: false, 
-          renewed: false
-          }
-        end
-
-        let(:updated_license_data) do 
-          {
-          written: true, 
-          license: false, 
-          renewed: false
-          }
-        end
-
         it 'cannot administer a written test to a registrant if the facility does not offer that Service' do
-          expect(veruca.license_data).to eq(original_license_data)
-          veruca.earn_permit
-          facility_1.administer_written_test(veruca)
-          expect(veruca.license_data).to eq(updated_license_data)
+          expect(violet.license_data).to eq(original_license_data)
+          facility_1.administer_written_test(violet)
+          expect(violet.license_data).to eq(updated_license_data)
 
-          expect(facility_1.administer_road_test(veruca)).to eq(false)
-          expect(veruca.license_data).to eq(updated_license_data)
+          expect(facility_1.administer_road_test(violet)).to eq(false)
+          expect(violet.license_data).to eq(updated_license_data)
         end
 
         it 'cannot adminster a road test to a registrant who only has a permit (did not take written test)' do
@@ -249,18 +201,14 @@ RSpec.describe Facility do
 
           expect(veruca.license_data).to eq(original_license_data)
           expect(facility_1.administer_road_test(veruca)).to eq(false)
-          veruca.earn_permit
+          expect(veruca.license_data).to eq(original_license_data)
 
+          veruca.earn_permit
           expect(facility_1.administer_road_test(veruca)).to eq(false)
           expect(veruca.license_data).to eq(original_license_data)
         end
       end
     end
-
-    # let(:willy_wonka) { Registrant.new(name: "Willy Wonka", age: 40) }
-    # let(:charlie) { Registrant.new(name: "Charlie Bucket", age: 14, permit: true) }
-    # let(:violet) { Registrant.new(name: "Violet Beauregarde", age: 16, permit: true) }
-    # let(:veruca) { Registrant.new(name: "Veruca Salt", age: 16) }
 
     describe '#renew_drivers_license' do
       describe 'happy path tests' do
@@ -268,38 +216,6 @@ RSpec.describe Facility do
           facility_1.add_service('Written Test')
           facility_1.add_service('Road Test')
           facility_1.add_service('Renew License')
-        end
-
-        let(:original_license_data) do 
-          {
-          written: false, 
-          license: false, 
-          renewed: false
-          }
-        end
-
-        let(:updated_license_data) do 
-          {
-          written: true, 
-          license: false, 
-          renewed: false
-          }
-        end
-
-        let(:received_license_data) do 
-          {
-          written: true, 
-          license: true, 
-          renewed: false
-          }
-        end
-
-        let(:renewed_license_data) do 
-          {
-          written: true, 
-          license: true, 
-          renewed: true
-          }
         end
 
         it "can renew a license if facility offers Service & registrant has a current license" do
@@ -319,30 +235,6 @@ RSpec.describe Facility do
           facility_1.add_service('Road Test')
         end
 
-        let(:original_license_data) do 
-          {
-          written: false, 
-          license: false, 
-          renewed: false
-          }
-        end
-        
-        let(:updated_license_data) do 
-          {
-          written: true, 
-          license: false, 
-          renewed: false
-          }
-        end
-
-        let(:received_license_data) do 
-          {
-          written: true, 
-          license: true, 
-          renewed: false
-          }
-        end
-
         it 'cannot renew a license to a registrant if the facility does not offer that Service' do
           expect(violet.license_data).to eq(original_license_data)
           facility_1.administer_written_test(violet)
@@ -355,6 +247,7 @@ RSpec.describe Facility do
 
         it 'cannot renew a license if a registrant does not currently have a license' do
           facility_1.add_service('Renew License')
+
           expect(violet.license_data).to eq(original_license_data)
           expect(facility_1.renew_license(violet)).to eq(false)
           expect(violet.license_data).to eq(original_license_data)

--- a/spec/facility_spec.rb
+++ b/spec/facility_spec.rb
@@ -171,12 +171,6 @@ RSpec.describe Facility do
       end
     end
 
-    # let(:willy_wonka) { Registrant.new(name: "Willy Wonka", age: 40) }
-    # let(:charlie) { Registrant.new(name: "Charlie Bucket", age: 14, permit: true) }
-    # let(:violet) { Registrant.new(name: "Violet Beauregarde", age: 16, permit: true) }
-    # let(:veruca) { Registrant.new(name: "Veruca Salt", age: 16) }
-
-
     describe '#administer_road_test' do
       describe 'happy path tests' do
         before(:each) do
@@ -208,7 +202,7 @@ RSpec.describe Facility do
           }
         end
 
-        it 'can administer a road test & earn license to registrant who passes the written test' do
+        it 'can administer a road test if facility offers Service & give license to registrant who passes the written test' do
           expect(veruca.license_data).to eq(original_license_data)
           veruca.earn_permit
           facility_1.administer_written_test(veruca)
@@ -263,7 +257,114 @@ RSpec.describe Facility do
       end
     end
 
-    # describe '#renew_drivers_license' do
-    # end
+    # let(:willy_wonka) { Registrant.new(name: "Willy Wonka", age: 40) }
+    # let(:charlie) { Registrant.new(name: "Charlie Bucket", age: 14, permit: true) }
+    # let(:violet) { Registrant.new(name: "Violet Beauregarde", age: 16, permit: true) }
+    # let(:veruca) { Registrant.new(name: "Veruca Salt", age: 16) }
+
+    describe '#renew_drivers_license' do
+      describe 'happy path tests' do
+        before(:each) do
+          facility_1.add_service('Written Test')
+          facility_1.add_service('Road Test')
+          facility_1.add_service('Renew License')
+        end
+
+        let(:original_license_data) do 
+          {
+          written: false, 
+          license: false, 
+          renewed: false
+          }
+        end
+
+        let(:updated_license_data) do 
+          {
+          written: true, 
+          license: false, 
+          renewed: false
+          }
+        end
+
+        let(:received_license_data) do 
+          {
+          written: true, 
+          license: true, 
+          renewed: false
+          }
+        end
+
+        let(:renewed_license_data) do 
+          {
+          written: true, 
+          license: true, 
+          renewed: true
+          }
+        end
+
+        it "can renew a license if facility offers Service & registrant has a current license" do
+          expect(violet.license_data).to eq(original_license_data)
+          facility_1.administer_written_test(violet)
+          facility_1.administer_road_test(violet)
+          expect(violet.license_data).to eq(received_license_data)
+
+          expect(facility_1.renew_license(violet)).to eq(true)
+          expect(violet.license_data).to eq(renewed_license_data)
+        end
+      end
+
+      describe 'sad path tests' do
+        before(:each) do
+          facility_1.add_service('Written Test')
+          facility_1.add_service('Road Test')
+        end
+
+        let(:original_license_data) do 
+          {
+          written: false, 
+          license: false, 
+          renewed: false
+          }
+        end
+        
+        let(:updated_license_data) do 
+          {
+          written: true, 
+          license: false, 
+          renewed: false
+          }
+        end
+
+        let(:received_license_data) do 
+          {
+          written: true, 
+          license: true, 
+          renewed: false
+          }
+        end
+
+        it 'cannot renew a license to a registrant if the facility does not offer that Service' do
+          expect(violet.license_data).to eq(original_license_data)
+          facility_1.administer_written_test(violet)
+          facility_1.administer_road_test(violet)
+          expect(violet.license_data).to eq(received_license_data)
+
+          expect(facility_1.renew_license(violet)).to eq(false)
+          expect(violet.license_data).to eq(received_license_data)
+        end
+
+        it 'cannot renew a license if a registrant does not currently have a license' do
+          facility_1.add_service('Renew License')
+          expect(violet.license_data).to eq(original_license_data)
+          expect(facility_1.renew_license(violet)).to eq(false)
+          expect(violet.license_data).to eq(original_license_data)
+
+          facility_1.administer_written_test(violet)
+          expect(violet.license_data).to eq(updated_license_data)
+          expect(facility_1.renew_license(violet)).to eq(false)
+          expect(violet.license_data).to eq(updated_license_data)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Changes
- Added happy & sad path testing for #renew_license
- Created #renew-license
- DRY-ed up tests & cleaned up Facility class
- Added note on future refactor: create ServiceFactory class since 3 look like Duck Types